### PR TITLE
Added the getter method for the event details

### DIFF
--- a/src/main/java/de/jpx3/intave/access/check/event/IntaveViolationEvent.java
+++ b/src/main/java/de/jpx3/intave/access/check/event/IntaveViolationEvent.java
@@ -84,6 +84,13 @@ public final class IntaveViolationEvent extends IntaveEvent implements Cancellab
   }
 
   /**
+   * @return the details of this violation.
+   */
+  public String getDetails() {
+    return this.details;
+  }
+
+  /**
    * Retrieve the detection message without details.
    * Usually in a format where it can be prefixed with the players name (e.g. "moved incorrectly")
    * @return a generalized message for this violation

--- a/src/main/java/de/jpx3/intave/access/check/event/IntaveViolationEvent.java
+++ b/src/main/java/de/jpx3/intave/access/check/event/IntaveViolationEvent.java
@@ -86,7 +86,7 @@ public final class IntaveViolationEvent extends IntaveEvent implements Cancellab
   /**
    * @return the details of this violation.
    */
-  public String getDetails() {
+  public String details() {
     return this.details;
   }
 


### PR DESCRIPTION
As I said in the title, a method to get the details of the event is necessary because the original plugin is obfuscated.